### PR TITLE
#10 fix: 페이지 라우팅 구조 정비 및 Header/Footer 전역 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.1.12",
-        "lucide-react": "^0.542.0",
         "clsx": "^2.1.1",
+        "lucide-react": "^0.542.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-router-dom": "^7.8.2",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,11 +7,12 @@ import {
 import MainPage from './pages/MainPage';
 import SpaceDetailPage from './pages/SpaceDetailPage';
 import SpaceListPage from './pages/SpaceListPage';
+import Layout from './layout/Layout';
 
 const App = () => {
   const router = createBrowserRouter(
     createRoutesFromElements(
-      <Route path='/'>
+      <Route path='/' element={<Layout />}>
         <Route index element={<MainPage />} />
         <Route path='spaces' element={<SpaceListPage />} />
         <Route path='spaces/:id' element={<SpaceDetailPage />} />

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -7,17 +7,18 @@ export default function Header() {
   const location = useLocation();
 
   const goToMainAndScroll = (section) => {
-    if (location.pathname === '/mainpage') {
-      navigate('/mainpage', {state: {scrollTo: section}});
+    if (location.pathname === '/') {
+      navigate('/', {state: {scrollTo: section}});
     } else {
-      navigate('/mainpage', {state: {scrollTo: section}});
+      navigate('/', {state: {scrollTo: section}});
     }
   };
+
   return (
     <header className='sticky top-0 z-20 bg-[#F2F1EC]/80 backdrop-blur border-b border-neutral-300/70'>
       <div className='mx-auto max-w-6xl px-5 h-16 flex items-center justify-between'>
         <div className='flex items-center gap-6 '>
-          <Link to='/mainpage' onClick={() => goToMainAndScroll('top')}>
+          <Link to='/' onClick={() => goToMainAndScroll('top')}>
             <img
               src='src/assets/dotdotdot_logo.png'
               alt='logo'

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -1,55 +1,69 @@
-import { Instagram, Menu, Globe } from "lucide-react";
-import { use } from "react";
-import { Link , useNavigate, useLocation} from "react-router-dom";
+import {Instagram, Menu, Globe} from 'lucide-react';
+import {use} from 'react';
+import {Link, useNavigate, useLocation} from 'react-router-dom';
 
 export default function Header() {
+  const navigate = useNavigate();
+  const location = useLocation();
 
-  const naviagte=useNavigate();
-  const location=useLocation();
-
-  const goToMainAndScroll=(section) => {
-    if (location.pathname==="/mainpage"){
-      navigate("/mainpage", {state: {scrollTo: section}});
-
-    } else{
-      navigate("/mainpage", {state: {scrollTo: section}});
+  const goToMainAndScroll = (section) => {
+    if (location.pathname === '/mainpage') {
+      navigate('/mainpage', {state: {scrollTo: section}});
+    } else {
+      navigate('/mainpage', {state: {scrollTo: section}});
     }
-  }
+  };
   return (
-    <header className="sticky top-0 z-20 bg-[#F2F1EC]/80 backdrop-blur border-b border-neutral-300/70">
-      <div className="mx-auto max-w-6xl px-5 h-16 flex items-center justify-between">
-        <div className="flex items-center gap-6 ">
-          <Link to="/mainpage" onClick={() => goToMainAndScroll("top")}>
-            <img src="src/assets/dotdotdot_logo.png" alt="logo" className="h-8" />
+    <header className='sticky top-0 z-20 bg-[#F2F1EC]/80 backdrop-blur border-b border-neutral-300/70'>
+      <div className='mx-auto max-w-6xl px-5 h-16 flex items-center justify-between'>
+        <div className='flex items-center gap-6 '>
+          <Link to='/mainpage' onClick={() => goToMainAndScroll('top')}>
+            <img
+              src='src/assets/dotdotdot_logo.png'
+              alt='logo'
+              className='h-8'
+            />
           </Link>
-          <nav className="hidden md:flex items-center gap-6 text-sm text-neutral-600">
-            <Link className="hover:text-black" to="/spaces">창작 공간들</Link>
-            <Link className="hover:text-black" onClick={() => goToMainAndScroll("schedule")}>행사 일정</Link>
-            <Link className="hover:text-black" onClick={() => goToMainAndScroll("event")}>이벤트 정보</Link>
+          <nav className='hidden md:flex items-center gap-6 text-sm text-neutral-600'>
+            <Link className='hover:text-black' to='/spaces'>
+              창작 공간들
+            </Link>
+            <Link
+              className='hover:text-black'
+              onClick={() => goToMainAndScroll('schedule')}>
+              행사 일정
+            </Link>
+            <Link
+              className='hover:text-black'
+              onClick={() => goToMainAndScroll('event')}>
+              이벤트 정보
+            </Link>
           </nav>
         </div>
-        <div className="flex items-center gap-3 text-neutral-600">
-          <a 
-          aria-label="instagram" 
-          href="https://www.instagram.com/3point_incheon/" 
-          className="p-3 hover:text-black">
+        <div className='flex items-center gap-3 text-neutral-600'>
+          <a
+            aria-label='instagram'
+            href='https://www.instagram.com/3point_incheon/'
+            className='p-3 hover:text-black'>
             <img
-             src="src/assets/ig_logo.jpg"
-             alt="instagram"
-             className="w-5 h-5"
-             />
-             </a>
+              src='src/assets/ig_logo.jpg'
+              alt='instagram'
+              className='w-5 h-5'
+            />
+          </a>
 
-            <a
-            href="https://blog.naver.com/ifacpr"
-            className="p-8 hover:text-black">
-                <img
-                src="src/assets/blog_logo.png"
-                alt="global"
-                className="w-7 h-7"
-                />
-            </a>
-          <button className="px-3 py-1.5 rounded-full border border-neutral-300 text-xs hover:bg-white">공식 사이트</button>
+          <a
+            href='https://blog.naver.com/ifacpr'
+            className='p-8 hover:text-black'>
+            <img
+              src='src/assets/blog_logo.png'
+              alt='global'
+              className='w-7 h-7'
+            />
+          </a>
+          <button className='px-3 py-1.5 rounded-full border border-neutral-300 text-xs hover:bg-white'>
+            공식 사이트
+          </button>
         </div>
       </div>
     </header>

--- a/src/components/mainpage/Preview.jsx
+++ b/src/components/mainpage/Preview.jsx
@@ -37,7 +37,8 @@ const Preview = ({setHover}) => {
           <div
             onMouseEnter={() => setHover(true)}
             onMouseLeave={() => setHover(false)}
-            onClick={() => navigate(`spaces/${index + 1}`)}
+            // onClick={() => navigate(`spaces/${index + 1}`)}
+            onClick={() => navigate(`spaces/4`)}
             key={id}
             className='absolute group flex flex-col items-center cursor-pointer hover:drop-shadow-hover hover:z-30'
             style={{

--- a/src/layout/Layout.jsx
+++ b/src/layout/Layout.jsx
@@ -1,0 +1,17 @@
+import {Outlet} from 'react-router-dom';
+import Footer from '../components/footer';
+import Header from '../components/header';
+
+const Layout = () => {
+  return (
+    <div>
+      <Header />
+      <main>
+        <Outlet />
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default Layout;

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -10,7 +10,7 @@ const MainPage = () => {
   const [hover, setHover] = useState(false);
 
   return (
-    <div className='flex justify-center py-20'>
+    <div className='relative flex justify-center py-20'>
       <img className='absolute z-0 top-8 left-7' src={title} alt='' />
       {hover && (
         <img className={`absolute z-10`} src={background_blur} alt='' />

--- a/src/pages/SpaceListPage.jsx
+++ b/src/pages/SpaceListPage.jsx
@@ -1,144 +1,200 @@
-import { ArrowDownRight } from 'lucide-react';
-import { useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
+import {ArrowDownRight} from 'lucide-react';
+import {useMemo} from 'react';
+import {useNavigate} from 'react-router-dom';
 import Header from '../components/header';
-import Footer from '../components/footer'
-import listPageBg from '../assets/ListPageBg.png'
+import Footer from '../components/footer';
+import listPageBg from '../assets/ListPageBg.png';
 import {useRef} from 'react';
-
 
 // district 조건과 같이 화살표 색상 설정
 function getDistrictTextColor(region, district) {
-    const key = `${region}|${district}`;
-    const clasName=districtColors[key];
+  const key = `${region}|${district}`;
+  const clasName = districtColors[key];
 
-    const match=clasName?.match(/text-\[#([0-9a-fA-F]{6})\]/);
-    return match? `#${match[1]}`: 'text-neutral-600';
+  const match = clasName?.match(/text-\[#([0-9a-fA-F]{6})\]/);
+  return match ? `#${match[1]}` : 'text-neutral-600';
 }
 
 // className 유틸리티 함수
 const cx = (...classes) => classes.filter(Boolean).join(' ');
 
-const districtColors={
-    "미추홀구|인천 남구": "border-[#7268FF] text-[#7268FF]",
-    "중구|인천": "border-[#4DAB4E] text-[#4DAB4E]",
-    "동구|인천": "border-[#F4A301] text-[#F4A301]",
-}
-
+const districtColors = {
+  '미추홀구|인천 남구': 'border-[#7268FF] text-[#7268FF]',
+  '중구|인천': 'border-[#4DAB4E] text-[#4DAB4E]',
+  '동구|인천': 'border-[#F4A301] text-[#F4A301]',
+};
 
 const ListPage = () => {
-    const navigate = useNavigate();
-    
-    const items = useMemo(() => [
-        { id: "1", title: "작업장 ‘봄’", region: "미추홀구", district: "인천 남구", image: "src/assets/coverimage/cover_ex.png" },
-        { id: "2", title: "(주) 위드달", region: "미추홀구", district: "인천 남구", image: "src/assets/coverimage/cover_ex.png" },
-        { id: "3", title: "코드아트", region: "미추홀구", district: "인천 남구", image: "src/assets/coverimage/cover_ex.png" },
-        { id: "4", title: "주식회사 한울소리", region: "미추홀구", district: "인천 남구", image: "src/assets/coverimage/cover_ex.png" },
-        { id: "4", title: "공간인공빛", region: "중구", district: "인천", image: "src/assets/coverimage/cover_ex.png" },
-        { id: "5", title: "공예루틴", region: "중구", district: "인천", image: "src/assets/coverimage/cover_ex.png" },
-        { id: "6", title: "모이소", region: "중구", district: "인천", image: "src/assets/coverimage/cover_ex.png" },
-        { id: "7", title: "올라 아트컴퍼니", region: "중구", district: "인천", image: "src/assets/coverimage/cover_ex.png" },
-        { id: "8", title: "창작집단 <발아>", region: "중구", district: "인천", image: "src/assets/coverimage/cover_ex.png" },
-        { id: "9", title: "카츠오리진 연구소", region: "중구", district: "인천", image: "src/assets/coverimage/cover_ex.png" },
-        { id: "10", title: "어벙또벙 이야기 수선점", region: "동구", district: "인천", image: "src/assets/coverimage/cover_ex.png" },
-    ], []);
+  const navigate = useNavigate();
 
+  const items = useMemo(
+    () => [
+      {
+        id: '1',
+        title: '작업장 ‘봄’',
+        region: '미추홀구',
+        district: '인천 남구',
+        image: 'src/assets/coverimage/cover_ex.png',
+      },
+      {
+        id: '2',
+        title: '(주) 위드달',
+        region: '미추홀구',
+        district: '인천 남구',
+        image: 'src/assets/coverimage/cover_ex.png',
+      },
+      {
+        id: '3',
+        title: '코드아트',
+        region: '미추홀구',
+        district: '인천 남구',
+        image: 'src/assets/coverimage/cover_ex.png',
+      },
+      {
+        id: '4',
+        title: '주식회사 한울소리',
+        region: '미추홀구',
+        district: '인천 남구',
+        image: 'src/assets/coverimage/cover_ex.png',
+      },
+      {
+        id: '4',
+        title: '공간인공빛',
+        region: '중구',
+        district: '인천',
+        image: 'src/assets/coverimage/cover_ex.png',
+      },
+      {
+        id: '5',
+        title: '공예루틴',
+        region: '중구',
+        district: '인천',
+        image: 'src/assets/coverimage/cover_ex.png',
+      },
+      {
+        id: '6',
+        title: '모이소',
+        region: '중구',
+        district: '인천',
+        image: 'src/assets/coverimage/cover_ex.png',
+      },
+      {
+        id: '7',
+        title: '올라 아트컴퍼니',
+        region: '중구',
+        district: '인천',
+        image: 'src/assets/coverimage/cover_ex.png',
+      },
+      {
+        id: '8',
+        title: '창작집단 <발아>',
+        region: '중구',
+        district: '인천',
+        image: 'src/assets/coverimage/cover_ex.png',
+      },
+      {
+        id: '9',
+        title: '카츠오리진 연구소',
+        region: '중구',
+        district: '인천',
+        image: 'src/assets/coverimage/cover_ex.png',
+      },
+      {
+        id: '10',
+        title: '어벙또벙 이야기 수선점',
+        region: '동구',
+        district: '인천',
+        image: 'src/assets/coverimage/cover_ex.png',
+      },
+    ],
+    []
+  );
 
-    return (
-        <div className="min-h-svh flex flex-col bg-[#FAFAF7] text-[#1A1A1A]">
-          <Header />
-      
-          <main
-            className="flex-grow bg-cover bg-bottom bg-contain"
-            style={{ backgroundImage: `url(${listPageBg})` }}
-          >
-            <div className="mx-auto max-w-6xl px-5 py-12">
-              {/* 그리드 라인 */}
-              <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-0 border-t border-l border-neutral-300">
-                {items.map((p) => (
-                  <Card key={p.id} place={p} />
-                ))}
-              </section>
-            </div>
-          </main>
-      
-          <Footer />
+  return (
+    <div className='min-h-svh flex flex-col bg-[#FAFAF7] text-[#1A1A1A]'>
+      <Header />
+
+      <main
+        className='flex-grow bg-cover bg-bottom bg-contain'
+        style={{backgroundImage: `url(${listPageBg})`}}>
+        <div className='mx-auto max-w-6xl px-5 py-12'>
+          {/* 그리드 라인 */}
+          <section className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-0 border-t border-l border-neutral-300'>
+            {items.map((p) => (
+              <Card key={p.id} place={p} />
+            ))}
+          </section>
         </div>
-      );
-}
-      
-        
-        // 카드
-        function Card({ place }) {
-        return (
-        <article
-        className={cx(
-        "relative isolate bg-white overflow-hidden",
-        "min-h-[220px] group transition-colors border-r border-b border-neutral-300"
-        )}
-        >
-        {/* 배경 이미지 */}
-        <div
+      </main>
+
+      <Footer />
+    </div>
+  );
+};
+
+// 카드
+function Card({place}) {
+  const navigate = useNavigate();
+  return (
+    <article
+      onClick={() => navigate(`4`)} // 카드 컴포넌트 클릭 시 spaces/4로 이동
+      className={cx(
+        'relative isolate bg-white overflow-hidden',
+        'min-h-[220px] group transition-colors border-r border-b border-neutral-300'
+      )}>
+      {/* 배경 이미지 */}
+      <div
         aria-hidden
-        className="absolute inset-0 z-0 bg-center bg-cover opacity-0 transition-opacity duration-500 ease-out group-hover:opacity-100"
-        style={{ backgroundImage: `url(${place.image})` }}
-        />
-        <div
+        className='absolute inset-0 z-0 bg-center bg-cover opacity-0 transition-opacity duration-500 ease-out group-hover:opacity-100'
+        style={{backgroundImage: `url(${place.image})`}}
+      />
+      <div
         aria-hidden
-        className="absolute inset-0 z-0 opacity-0 group-hover:opacity-100 transition-opacity duration-500 bg-[linear-gradient(to_top,rgba(0,0,0,.45),rgba(0,0,0,.1),transparent)]"
-        />
-        
-        
-        {/* 상단: 타이틀만 */}
-        <div className="relative z-10 px-4 pt-3 pb-6">
-        <h3 className="text-3xl font-black tracking-tight text-neutral-900 group-hover:text-white transition-colors break-keep">
-        {place.title}
+        className='absolute inset-0 z-0 opacity-0 group-hover:opacity-100 transition-opacity duration-500 bg-[linear-gradient(to_top,rgba(0,0,0,.45),rgba(0,0,0,.1),transparent)]'
+      />
+
+      {/* 상단: 타이틀만 */}
+      <div className='relative z-10 px-4 pt-3 pb-6'>
+        <h3 className='text-3xl font-black tracking-tight text-neutral-900 group-hover:text-white transition-colors break-keep'>
+          {place.title}
         </h3>
-        </div>
-        
-        
-        {/* 좌측하단: 배지 */}
-        <div className="absolute left-3 bottom-3 z-10 flex items-center gap-2 text-[11px] font-black group-hover:text-white transition-colors break-keep">
-            {/* region은 공통 스타일 */}
-            <Badge>{place.region.toUpperCase()}</Badge>
+      </div>
 
-             {/* district는 region + district 조합 색상 */}
-            <Badge region={place.region} district={place.district}>
-                {place.district}
-            </Badge>
-        </div>
+      {/* 좌측하단: 배지 */}
+      <div className='absolute left-3 bottom-3 z-10 flex items-center gap-2 text-[11px] font-black group-hover:text-white transition-colors break-keep'>
+        {/* region은 공통 스타일 */}
+        <Badge>{place.region.toUpperCase()}</Badge>
 
-        
-        
-        {/* 우측하단: 자세히 보기 */}
-        <a
-        href="#"
-        className="absolute right-3 bottom-3 z-10 inline-flex items-center gap-1.5 text-[11px] text-neutral-600 group-hover:text-white transition-colors"
-        style={{ color: getDistrictTextColor(place.region, place.district) }}
-        >
-         <ArrowDownRight size={25} />
-        </a>
-        </article>
-        );
-        }
-        
-        
-        // 배지
-        function Badge({ children, region, district }) {
-            const key=`${region}|${district}`;
-            const colorClass=
-                districtColors[key] || "bg-[#000000] text-[#FFFFFF] border-neutral-200 transition-colors group-hover:bg-transparent group-hover:text-white group-hover:border-white";
-        
-            return(
-                <span
-                    className={cx(
-                        "px-2.5 py-1 rounded-full border text-[11px]",colorClass
-                    )}
-                >
-                    {children}
-                </span>
-            );
-        }
+        {/* district는 region + district 조합 색상 */}
+        <Badge region={place.region} district={place.district}>
+          {place.district}
+        </Badge>
+      </div>
 
+      {/* 우측하단: 자세히 보기 */}
+      <a
+        href='#'
+        className='absolute right-3 bottom-3 z-10 inline-flex items-center gap-1.5 text-[11px] text-neutral-600 group-hover:text-white transition-colors'
+        style={{color: getDistrictTextColor(place.region, place.district)}}>
+        <ArrowDownRight size={25} />
+      </a>
+    </article>
+  );
+}
+
+// 배지
+function Badge({children, region, district}) {
+  const key = `${region}|${district}`;
+  const colorClass =
+    districtColors[key] ||
+    'bg-[#000000] text-[#FFFFFF] border-neutral-200 transition-colors group-hover:bg-transparent group-hover:text-white group-hover:border-white';
+
+  return (
+    <span
+      className={cx('px-2.5 py-1 rounded-full border text-[11px]', colorClass)}>
+      {children}
+    </span>
+  );
+}
 
 export default ListPage;

--- a/src/pages/SpaceListPage.jsx
+++ b/src/pages/SpaceListPage.jsx
@@ -112,7 +112,7 @@ const ListPage = () => {
 
   return (
     <div className='min-h-svh flex flex-col bg-[#FAFAF7] text-[#1A1A1A]'>
-      <Header />
+      {/* <Header /> */}
 
       <main
         className='flex-grow bg-cover bg-bottom bg-contain'
@@ -127,7 +127,7 @@ const ListPage = () => {
         </div>
       </main>
 
-      <Footer />
+      {/* <Footer /> */}
     </div>
   );
 };


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
Closed #10 


<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->
**라우팅 구조 개선**
- 중간 페이지 → 상세 페이지(spaces/4) 이동 기능 구현
- 창작공간 공 클릭 시 spaces/4로 임시 이동 처리
- Header 네비게이션 경로를 /mainpage → /로 수정

**공통 레이아웃 적용**
- Outlet 기반 공통 레이아웃(Layout) 구성
- Header/Footer를 모든 페이지에 전역 적용

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->

https://github.com/user-attachments/assets/177dcf29-2c5b-49ce-97b2-4f64dbaa92f8

https://github.com/user-attachments/assets/9340ee78-1c0e-41d2-a091-cf768824f26e



<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
@ygkgy0105  

메인페이지에서 Header 내 스크롤 이동 시 불필요하게 navigate가 호출되는 부분이 있어요
해당 로직은 추후 정리하여 불필요한 페이지 이동 없이 스크롤만 처리되도록 개선하는 것이 좋을 것 같습니다!

```jsx
const goToMainAndScroll = (section) => {
    if (location.pathname === '/') {
      navigate('/', {state: {scrollTo: section}});
    } else {
      navigate('/', {state: {scrollTo: section}});
    }
  };
```
<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->