### PR TITLE
#14 chore: 이미지 import 방식으로 불러오고 페이지 제목 변경

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>2025 점점점</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/pages/SpaceListPage.jsx
+++ b/src/pages/SpaceListPage.jsx
@@ -4,6 +4,7 @@ import {useNavigate} from 'react-router-dom';
 import Header from '../components/header';
 import Footer from '../components/footer';
 import listPageBg from '../assets/ListPageBg.png';
+import thumbnail from '../assets/coverimage/cover_ex.png';
 import {useRef} from 'react';
 
 // district 조건과 같이 화살표 색상 설정
@@ -146,7 +147,8 @@ function Card({place}) {
       <div
         aria-hidden
         className='absolute inset-0 z-0 bg-center bg-cover opacity-0 transition-opacity duration-500 ease-out group-hover:opacity-100'
-        style={{backgroundImage: `url(${place.image})`}}
+        // style={{backgroundImage: `url(${place.image})`}}
+        style={{backgroundImage: `url(${thumbnail})`}}
       />
       <div
         aria-hidden


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
Related #14 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->
- 페이지 제목을 **2025 점점점** 으로 변경  
- `src="src/..."` 방식으로 불러오던 이미지를 `import` 방식으로 가져와 배포 환경에서도 이미지가 정상적으로 표시되도록 수정

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->
<img width="1099" height="529" alt="Screenshot 2025-10-07 at 20 19 44" src="https://github.com/user-attachments/assets/906b1276-ac66-4735-b5b2-001a396190e9" />



<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->